### PR TITLE
Quartermaster

### DIFF
--- a/script/QuartermasterShaman.s.sol
+++ b/script/QuartermasterShaman.s.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+import { Script, console2 } from "forge-std/Script.sol";
+import { QuartermasterShaman } from "../src/QuartermasterShaman.sol";
+import {
+  HatsModuleFactory, deployModuleFactory, deployModuleInstance
+} from "lib/hats-module/src/utils/DeployFunctions.sol";
+
+contract DeployImplementation is Script {
+  QuartermasterShaman public implementation;
+  bytes32 public SALT = keccak256("lets add some salt to this meal");
+
+  // default values
+  string public version = "0.1.0"; // increment with each deploy
+  bool private verbose = true;
+
+  /// @notice Override default values, if desired
+  function prepare(string memory _version, bool _verbose) public {
+    version = _version;
+    verbose = _verbose;
+  }
+
+  function run() public {
+    uint256 privKey = vm.envUint("PRIVATE_KEY");
+    address deployer = vm.rememberKey(privKey);
+    vm.startBroadcast(deployer);
+
+    implementation = new QuartermasterShaman{ salt: SALT}(version);
+
+    vm.stopBroadcast();
+
+    if (verbose) {
+      console2.log("QuartermasterShaman:", address(implementation));
+    }
+  }
+
+  // forge script script/QuartermasterShaman.s.sol:DeployImplementation -f ethereum --broadcast --verify
+}
+
+contract DeployInstance is Script {
+  HatsModuleFactory public factory;
+  address public implementation;
+  address public instance;
+  uint256 public hatId;
+  bytes public otherImmutableArgs;
+  bytes public initData;
+  bool internal verbose = true;
+  bool internal defaults = true;
+
+  /// @dev override this to abi.encode (packed) other relevant immutable args (initialized and set within the function
+  /// body). Alternatively, you can pass encoded data in
+  function encodeImmutableArgs() internal virtual returns (bytes memory) {
+    // abi.encodePacked()...
+  }
+
+  /// @dev override this to abi.encode (unpacked) the init data (initialized and set within the function body)
+  function encodeInitData() internal virtual returns (bytes memory) {
+    // abi.encode()...
+  }
+
+  /// @dev override this to set the default values within the function body
+  function setDefaultValues() internal virtual {
+    // factory = HatsModuleFactory(0x);
+    // implementation = 0x;
+    // hatId = ;
+  }
+
+  /// @dev Call from tests or other scripts to override default values
+  function prepare(
+    HatsModuleFactory _factory,
+    address _implementation,
+    uint256 _hatId,
+    bytes memory _otherImmutableArgs,
+    bytes memory _initData,
+    bool _verbose
+  ) public {
+    factory = _factory;
+    implementation = _implementation;
+    hatId = _hatId;
+    otherImmutableArgs = _otherImmutableArgs;
+    initData = _initData;
+    verbose = _verbose;
+
+    defaults = false;
+  }
+
+  /// @dev Designed for override to not be necessary (all changes / config can be made in above functions), but can be
+  /// if desired
+  function run() public virtual {
+    uint256 privKey = vm.envUint("PRIVATE_KEY");
+    address deployer = vm.rememberKey(privKey);
+    vm.startBroadcast(deployer);
+
+    // if {prepare} was not called, then use the default values and encode the data
+    if (defaults) {
+      // set the default values
+      setDefaultValues();
+      // encode the other immutable args
+      otherImmutableArgs = encodeImmutableArgs();
+      // encode the init data
+      initData = encodeInitData();
+    }
+
+    // deploy the instance
+    instance = deployModuleInstance(factory, implementation, hatId, otherImmutableArgs, initData);
+
+    vm.stopBroadcast();
+
+    if (verbose) {
+      console2.log("Instance:", instance);
+    }
+  }
+
+  // forge script script/QuatermasterShaman.s.sol:DeployInstance -f ethereum --broadcast --verify
+}

--- a/src/QuartermasterShaman.sol
+++ b/src/QuartermasterShaman.sol
@@ -54,7 +54,8 @@ contract QuartermasterShaman is HatsModule {
    * 20      | HATS                | address | 20     | HatsModule       |
    * 40      | hatId               | uint256 | 32     | HatsModule       |
    * 72      | BAAL                | address | 20     | this             |
-   * 92      | OWNER_HAT           | uint256 | 32     | this             |
+   * 92      | CAPTAIN_HAT         | uint256 | 32     | this             |
+   * 124     | STARTING_SHARES     | uint256 | 32     | this             |
    * --------------------------------------------------------------------+
    */
 
@@ -63,8 +64,13 @@ contract QuartermasterShaman is HatsModule {
   }
 
   // OWNER_HAT is renamed to CAPTAIN_HAT for this use
+  // TODO I think this is wrong, this is brought from parent, captain should be initarg
   function CAPTAIN_HAT() public pure returns (uint256) {
     return _getArgUint256(92);
+  }
+
+  function STARTING_SHARES() public pure returns (uint256) {
+    return _getArgUint256(124);
   }
 
   /**
@@ -74,7 +80,6 @@ contract QuartermasterShaman is HatsModule {
    * cannot be mutated after initialization.
    */
   IBaalToken public SHARES_TOKEN;
-  uint256 public STARTING_SHARES;
 
   /*//////////////////////////////////////////////////////////////
                           MUTABLE STATE
@@ -94,13 +99,9 @@ contract QuartermasterShaman is HatsModule {
   //////////////////////////////////////////////////////////////*/
 
   /// @inheritdoc HatsModule
-  function _setUp(bytes calldata _initData) internal override {
+  function _setUp(bytes calldata) internal override {
     SHARES_TOKEN = IBaalToken(BAAL().sharesToken());
 
-    uint256 startingShares_ = abi.decode(_initData, (uint256));
-
-    // set the starting shares
-    STARTING_SHARES = startingShares_;
     // no need to emit an event, as this value is emitted in the HatsModuleFactory_ModuleDeployed event
   }
 
@@ -118,7 +119,7 @@ contract QuartermasterShaman is HatsModule {
       member = _members[i];
       if (onboardingDelay[member] == 0 && SHARES_TOKEN.balanceOf(member) == 0) {
         onboardingDelay[member] = delay;
-        amounts[i] = STARTING_SHARES; // else 0
+        amounts[i] = STARTING_SHARES(); // else 0
       }
 
       
@@ -168,7 +169,7 @@ contract QuartermasterShaman is HatsModule {
       address member = _members[i];
       if (onboardingDelay[member] != 0 && onboardingDelay[member] <= block.timestamp) {
         delete onboardingDelay[member];
-        amounts[i] = STARTING_SHARES;
+        amounts[i] = STARTING_SHARES();
       }
 
       unchecked {

--- a/src/QuartermasterShaman.sol
+++ b/src/QuartermasterShaman.sol
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+// import { console2 } from "forge-std/Test.sol"; // remove before deploy
+import { HatsModule } from "hats-module/HatsModule.sol";
+import { IBaal } from "baal/interfaces/IBaal.sol";
+import { IBaalToken } from "baal/interfaces/IBaalToken.sol";
+
+/**
+ * @title Quartermaster Shaman
+ * @notice A Baal manager shaman that allows onboarding, offboarding, and other DAO member management
+ * by the holder of the captain hat. The captain uses the quartermaster to give crew status to new members,
+ * but there is a delay to avoid the captain gathering crew to avoid a mutiny.
+ * @author @plor
+ * @dev This contract inherits from the HatsModule contract, and is meant to be deployed as a clone from the
+ * HatsModuleFactory.
+ */
+contract QuartermasterShaman is HatsModule {
+  /*//////////////////////////////////////////////////////////////
+                            CUSTOM ERRORS
+  //////////////////////////////////////////////////////////////*/
+
+  error NotCaptain();
+
+  /*//////////////////////////////////////////////////////////////
+                              EVENTS
+  //////////////////////////////////////////////////////////////*/
+
+  event OnboardedBatch(address[] members, uint256[] sharesPending, uint256 delay);
+  event OffboardedBatch(address[] members, uint256[] sharesPending, uint256 delay);
+  event Quartered(address[] members, uint256[] shares);
+  event Unquartered(address[] members, uint256[] shares);
+
+  /*//////////////////////////////////////////////////////////////
+                          PUBLIC CONSTANTS
+  //////////////////////////////////////////////////////////////*/
+
+  /**
+   * This contract is a clone with immutable args, which means that it is deployed with a set of
+   * immutable storage variables (ie constants). Accessing these constants is cheaper than accessing
+   * regular storage variables (such as those set on initialization of a typical EIP-1167 clone),
+   * but requires a slightly different approach since they are read from calldata instead of storage.
+   *
+   * Below is a table of constants and their locations. The first three are inherited from HatsModule.
+   *
+   * For more, see here: https://github.com/Saw-mon-and-Natalie/clones-with-immutable-args
+   *
+   * --------------------------------------------------------------------+
+   * CLONE IMMUTABLE "STORAGE"                                           |
+   * --------------------------------------------------------------------|
+   * Offset  | Constant            | Type    | Length | Source Contract  |
+   * --------------------------------------------------------------------|
+   * 0       | IMPLEMENTATION      | address | 20     | HatsModule       |
+   * 20      | HATS                | address | 20     | HatsModule       |
+   * 40      | hatId               | uint256 | 32     | HatsModule       |
+   * 72      | BAAL                | address | 20     | this             |
+   * 92      | OWNER_HAT           | uint256 | 32     | this             |
+   * --------------------------------------------------------------------+
+   */
+
+  function BAAL() public pure returns (IBaal) {
+    return IBaal(_getArgAddress(72));
+  }
+
+  // OWNER_HAT is renamed to CAPTAIN_HAT for this use
+  function CAPTAIN_HAT() public pure returns (uint256) {
+    return _getArgUint256(92);
+  }
+
+  /**
+   * @dev These are not stored as immutable args in order to enable instances to be set as shamans in new Baal
+   * deployments via `initializationActions`, which is not possible if these values determine an instance's address.
+   * While this means that they are stored normally in contract state, we still treat them as constants since they
+   * cannot be mutated after initialization.
+   */
+  IBaalToken public SHARES_TOKEN;
+  uint256 public STARTING_SHARES;
+
+  /*//////////////////////////////////////////////////////////////
+                          MUTABLE STATE
+  //////////////////////////////////////////////////////////////*/
+
+  mapping(address => uint256) public onboardingDelay;
+  mapping(address => uint256) public offboardingDelay;
+
+  /*//////////////////////////////////////////////////////////////
+                          CONSTRUCTOR
+  //////////////////////////////////////////////////////////////*/
+
+  constructor(string memory _version) HatsModule(_version) { }
+
+  /*//////////////////////////////////////////////////////////////
+                          INITIALIZER
+  //////////////////////////////////////////////////////////////*/
+
+  /// @inheritdoc HatsModule
+  function _setUp(bytes calldata _initData) internal override {
+    SHARES_TOKEN = IBaalToken(BAAL().sharesToken());
+
+    uint256 startingShares_ = abi.decode(_initData, (uint256));
+
+    // set the starting shares
+    STARTING_SHARES = startingShares_;
+    // no need to emit an event, as this value is emitted in the HatsModuleFactory_ModuleDeployed event
+  }
+
+  /*//////////////////////////////////////////////////////////////
+                          SHAMAN LOGIC
+  //////////////////////////////////////////////////////////////*/
+
+  function onboard(address[] calldata _members) external wearsCaptainHat(msg.sender) {
+    uint256 length = _members.length;
+    uint256 delay = _calculateDelay();
+    uint256[] memory amounts = new uint256[](length);
+    address member;
+
+    for (uint256 i; i < length;) {
+      member = _members[i];
+      if (onboardingDelay[member] == 0 && SHARES_TOKEN.balanceOf(member) == 0) {
+        onboardingDelay[member] = delay;
+        amounts[i] = STARTING_SHARES; // else 0
+      }
+
+      
+      unchecked {
+        ++i;
+      }
+    }
+    emit OnboardedBatch(_members, amounts, delay);
+  }
+
+  /**
+   * @notice Offboards a batch of members from the DAO, if they are not wearing the member hat. Offboarded members
+   * lose their voting power, but keep a record of their previous shares in the form of loot.
+   * @param _members The addresses of the members to offboard.
+   */
+  function offboard(address[] calldata _members) external wearsCaptainHat(msg.sender) {
+    uint256 length = _members.length;
+    uint256 delay = _calculateDelay();
+    uint256[] memory amounts = new uint256[](length);
+    address member;
+    uint256 shares;
+
+    for (uint256 i; i < length;) {
+      member = _members[i];
+      shares = SHARES_TOKEN.balanceOf(member);
+      if (offboardingDelay[member] == 0 && shares > 0) {
+        offboardingDelay[member] = delay;
+        amounts[i] = shares; // else 0
+      }
+
+      unchecked {
+        ++i;
+      }
+    }
+
+    emit OffboardedBatch(_members, amounts, delay);
+  }
+
+  /**
+   * Executes onboarding
+   */
+  function quarter(address[] calldata _members) external {
+    uint256 length = _members.length;
+    uint256[] memory amounts = new uint256[](length);
+
+    for (uint256 i; i < length;) {
+      address member = _members[i];
+      if (onboardingDelay[member] != 0 && onboardingDelay[member] <= block.timestamp) {
+        delete onboardingDelay[member];
+        amounts[i] = STARTING_SHARES;
+      }
+
+      unchecked {
+        ++i;
+      }
+    }
+    BAAL().mintShares(_members, amounts);
+    emit Quartered(_members, amounts);
+  }
+
+  /**
+   * Executes onboarding
+   */
+  function unquarter(address[] calldata _members) external {
+    uint256 length = _members.length;
+    uint256[] memory amounts = new uint256[](length);
+
+    for (uint256 i; i < length;) {
+      address member = _members[i];
+      if (offboardingDelay[member] != 0 && offboardingDelay[member] <= block.timestamp) {
+        delete offboardingDelay[member];
+        amounts[i] = SHARES_TOKEN.balanceOf(member);
+      }
+
+      unchecked {
+        ++i;
+      }
+    }
+    BAAL().burnShares(_members, amounts);
+    emit Unquartered(_members, amounts);
+  }
+
+  /*//////////////////////////////////////////////////////////////
+                          PRIVATE FUNCTIONS
+  //////////////////////////////////////////////////////////////*/
+
+  /**
+   * @notice Adds votingPeriod x2 to the current time to allow for mutiny delay
+   */
+  function _calculateDelay() private view returns (uint256 delay) {
+    return block.timestamp + (2 * BAAL().votingPeriod());
+  }
+
+  /*//////////////////////////////////////////////////////////////
+                          MODIFIERS
+  //////////////////////////////////////////////////////////////*/
+
+  /**
+   * @notice Reverts if the caller is not wearing the member hat.
+   */
+  modifier wearsCaptainHat(address _user) {
+    if (!HATS().isWearerOfHat(_user, CAPTAIN_HAT())) revert NotCaptain();
+    _;
+  }
+}

--- a/src/QuartermasterShaman.sol
+++ b/src/QuartermasterShaman.sol
@@ -122,7 +122,6 @@ contract QuartermasterShaman is HatsModule {
         amounts[i] = STARTING_SHARES(); // else 0
       }
 
-      
       unchecked {
         ++i;
       }

--- a/test/QuartermasterShaman.t.sol
+++ b/test/QuartermasterShaman.t.sol
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+import { Test } from "forge-std/Test.sol";
+import { QuartermasterShaman } from "../src/QuartermasterShaman.sol";
+import { DeployImplementation } from "../script/QuartermasterShaman.s.sol";
+import {
+  IHats,
+  HatsModuleFactory,
+  deployModuleFactory,
+  deployModuleInstance
+} from "lib/hats-module/src/utils/DeployFunctions.sol";
+import { IBaal } from "baal/interfaces/IBaal.sol";
+import { IBaalToken } from "baal/interfaces/IBaalToken.sol";
+import { IBaalSummoner } from "baal/interfaces/IBaalSummoner.sol";
+
+contract QuartermasterShamanTest is DeployImplementation, Test {
+  // variables inherited from DeployImplementation script
+  // QuartermasterShaman public implementation;
+  // bytes32 public SALT;
+
+  uint256 public fork;
+  uint256 public BLOCK_NUMBER = 17_671_864; // the block number where v1.hatsprotocol.eth was deployed;
+
+  IHats public constant HATS = IHats(0x3bc1A0Ad72417f2d411118085256fC53CBdDd137); // v1.hatsprotocol.eth
+  string public FACTORY_VERSION = "factory test version";
+  string public SHAMAN_VERSION = "shaman test version";
+
+  error NotCaptain();
+
+  event OnboardedBatch(address[] members, uint256[] sharesPending, uint256 delay);
+  event OffboardedBatch(address[] members, uint256[] sharesPending, uint256 delay);
+  event Quartered(address[] members, uint256[] shares);
+  event Unquartered(address[] members, uint256[] shares);
+
+  function setUp() public virtual {
+    // create and activate a fork, at BLOCK_NUMBER
+    fork = vm.createSelectFork(vm.rpcUrl("mainnet"), BLOCK_NUMBER);
+
+    // deploy via the script
+    DeployImplementation.prepare(SHAMAN_VERSION, false); // set last arg to true to log deployment addresses
+    DeployImplementation.run();
+  }
+}
+
+contract WithInstanceTest is QuartermasterShamanTest {
+  HatsModuleFactory public factory;
+  QuartermasterShaman public shaman;
+  uint256 public hatId;
+  bytes public otherImmutableArgs;
+  bytes public initData;
+
+  address public zodiacFactory = 0x00000000000DC7F163742Eb4aBEf650037b1f588;
+  IBaalSummoner public summoner = IBaalSummoner(0x7e988A9db2F8597735fc68D21060Daed948a3e8C);
+  IBaal public baal;
+  IBaalToken public sharesToken;
+  IBaalToken public lootToken;
+  uint256 public startingShares;
+  uint256 public baalSaltNonce;
+
+  address[] public members;
+  uint256[] public sharesBurned;
+
+  uint256 public tophat;
+  uint256 public captainHat;
+  address public eligibility = makeAddr("eligibility");
+  address public toggle = makeAddr("toggle");
+  address public dao = makeAddr("dao");
+  address public captain = makeAddr("captain");
+  address public nonWearer = makeAddr("nonWearer");
+
+  address public predictedBaalAddress;
+  address public predictedShamanAddress;
+
+  uint256 public constant MIN_STARTING_SHARES = 1e18;
+
+  function deployInstance(address _baal, uint256 _captainHat, uint256 _startingShares)
+    public
+    returns (QuartermasterShaman)
+  {
+    // encode the other immutable args as packed bytes
+    otherImmutableArgs = abi.encodePacked(_baal, _captainHat, _startingShares);
+    // encoded the initData as unpacked bytes -- for QuartermasterShaman, we just need any non-empty bytes
+    initData = abi.encode(0);
+    // deploy the instance
+    return QuartermasterShaman(
+      deployModuleInstance(factory, address(implementation), 0, otherImmutableArgs, initData)
+    );
+  }
+
+  function deployBaalWithShaman(string memory _name, string memory _symbol, bytes32 _saltNonce, address _shaman)
+    public
+    returns (IBaal)
+  {
+    // encode initParams
+    bytes memory initializationParams = abi.encode(_name, _symbol, address(0), address(0), address(0), address(0));
+    // encode initial action to set the shaman
+    address[] memory shamans = new address[](1);
+    uint256[] memory permissions = new uint256[](1);
+    bytes memory governanceConfig = abi.encode(uint32(3600), uint32(0), uint256(0), uint256(0), uint256(0), uint256(0));
+    shamans[0] = _shaman;
+    permissions[0] = 2; // manager only
+    bytes[] memory initializationActions = new bytes[](2);
+    initializationActions[0] = abi.encodeCall(IBaal.setShamans, (shamans, permissions));
+    initializationActions[1] = abi.encodeCall(IBaal.setGovernanceConfig,(governanceConfig));
+    // deploy the baal
+    return IBaal(
+      summoner.summonBaalFromReferrer(initializationParams, initializationActions, uint256(_saltNonce), "referrer")
+    );
+  }
+
+  /// @dev props to @santteegt
+  function predictBaalAddress(bytes32 _saltNonce) public view returns (address baalAddress) {
+    address template = summoner.template();
+    bytes memory initializer = abi.encodeWithSignature("avatar()");
+
+    bytes32 salt = keccak256(abi.encodePacked(keccak256(initializer), uint256(_saltNonce)));
+
+    // This is how ModuleProxyFactory works
+    bytes memory deployment =
+    //solhint-disable-next-line max-line-length
+     abi.encodePacked(hex"602d8060093d393df3363d3d373d3d3d363d73", template, hex"5af43d82803e903d91602b57fd5bf3");
+
+    bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), zodiacFactory, salt, keccak256(deployment)));
+
+    // NOTE: cast last 20 bytes of hash to address
+    baalAddress = address(uint160(uint256(hash)));
+  }
+
+  function grantShares(address _member, uint256 _amount) public {
+    vm.prank(address(baal));
+    sharesToken.mint(_member, _amount);
+  }
+
+  function setVotingPeriod(uint32 _period) public {
+  }
+
+  function makeArray(address _addr) public pure returns (address[] memory) {
+    address[] memory addrArray = new address[](1);
+    addrArray[0] = _addr;
+    return addrArray;
+  }
+
+  function makeArray(uint256 _num) public pure returns (uint256[] memory) {
+    uint256[] memory numArray = new uint256[](1);
+    numArray[0] = _num;
+    return numArray;
+  }
+
+  function setUp() public virtual override {
+    super.setUp();
+    // set startingShares at 1
+    startingShares = 1 ether; // 1 shares
+
+    // deploy the hats module factory
+    factory = deployModuleFactory(HATS, SALT, FACTORY_VERSION);
+
+    // set up hats
+    tophat = HATS.mintTopHat(dao, "tophat", "dao.eth/tophat");
+    vm.startPrank(dao);
+    captainHat = HATS.createHat(tophat, "captainHat", 1, eligibility, toggle, true, "dao.eth/captainHat");
+    HATS.mintHat(captainHat, captain);
+    vm.stopPrank();
+
+    // predict the baal's address
+    predictedBaalAddress = predictBaalAddress(SALT);
+
+    // predict the shaman's address via the hats module factory
+    predictedShamanAddress =
+      factory.getHatsModuleAddress(address(implementation), 0, abi.encodePacked(predictedBaalAddress, captainHat, startingShares));
+
+    // deploy a test baal with the predicted shaman address
+    baal = deployBaalWithShaman("TEST_BAAL", "TEST_BAAL", SALT, predictedShamanAddress);
+
+    // find and set baal token addresses
+    sharesToken = IBaalToken(baal.sharesToken());
+
+    // deploy the shaman instance
+    shaman = deployInstance(predictedBaalAddress, captainHat, startingShares);
+
+    // ensure that the actual and predicted addresses are the same
+    require(address(baal) == predictedBaalAddress, "actual and predicted baal addresses do not match");
+    require(address(shaman) == predictedShamanAddress, "actual and predicted shaman addresses do not match");
+  }
+}
+
+contract Deployment is WithInstanceTest {
+  function test_setAsManagerShaman() public {
+    assertEq(baal.shamans(address(shaman)), 2);
+  }
+
+  function test_version() public {
+    assertEq(shaman.version(), SHAMAN_VERSION);
+  }
+
+  function test_baal() public {
+    assertEq(address(shaman.BAAL()), address(baal));
+    assertEq(address(shaman.BAAL()), predictBaalAddress(SALT));
+  }
+
+  function test_sharesToken() public {
+    assertEq(address(shaman.SHARES_TOKEN()), address(sharesToken));
+  }
+
+  function test_startingShares() public {
+    assertEq(shaman.STARTING_SHARES(), startingShares);
+  }
+
+}
+
+contract Onboarding is WithInstanceTest {
+  function test_captain_canOnboard() public {
+    address[] memory toOnboard = makeArray(nonWearer);
+    uint256[] memory shareArr = makeArray(startingShares);
+    vm.prank(captain);
+    vm.expectEmit(true, true, false, false);
+    emit OnboardedBatch(toOnboard, shareArr, 0);
+    shaman.onboard(toOnboard);
+
+    assertGt(shaman.onboardingDelay(nonWearer), 0);
+  }
+
+  function test_nonCaptain_reverts() public {
+    vm.prank(nonWearer);
+    vm.expectRevert(NotCaptain.selector);
+    address[] memory toOnboard = makeArray(nonWearer);
+    shaman.onboard(toOnboard);
+
+    assertEq(shaman.onboardingDelay(nonWearer), 0);
+  }
+
+  function test_hasShares_noop() public {
+    uint256 amount = 1 ether;
+    address[] memory toOnboard = makeArray(nonWearer);
+    vm.prank(address(baal));
+    sharesToken.mint(nonWearer, amount);
+
+    vm.prank(captain);
+    shaman.onboard(toOnboard);
+
+    assertEq(shaman.onboardingDelay(nonWearer), 0);
+  }
+
+  function test_inQueue_noop() public {
+    address[] memory toOnboard = makeArray(nonWearer);
+
+    vm.prank(captain);
+    shaman.onboard(toOnboard);
+
+    uint256 delay = shaman.onboardingDelay(nonWearer);
+
+    vm.warp(block.timestamp + 3600);
+
+    vm.prank(captain);
+    shaman.onboard(toOnboard);
+
+    assertEq(shaman.onboardingDelay(nonWearer), delay);
+  }
+}
+
+contract Quartering is WithInstanceTest {
+  function test_captain_canQuarter() public {
+    address[] memory toOnboard = makeArray(nonWearer);
+    uint256[] memory amounts = makeArray(startingShares);
+
+    vm.prank(captain);
+    shaman.onboard(toOnboard);
+    vm.warp(block.timestamp + 7200);
+
+    vm.prank(captain);
+    vm.expectEmit(true, false, false, true);
+    emit Quartered(toOnboard, amounts);
+    shaman.quarter(toOnboard);
+
+    assertEq(sharesToken.balanceOf(nonWearer), startingShares);
+    assertEq(shaman.onboardingDelay(nonWearer), 0);
+  }
+
+  function test_captain_tooSoon() public {
+    address[] memory toOnboard = makeArray(nonWearer);
+
+    vm.prank(captain);
+    shaman.onboard(toOnboard);
+    vm.warp(block.timestamp + 3600); // not long enough
+
+    vm.prank(captain);
+    shaman.quarter(toOnboard);
+
+    assertEq(sharesToken.balanceOf(nonWearer), 0);
+  }
+
+  function test_anyone_canQuarter() public {
+    address[] memory toOnboard = makeArray(nonWearer);
+
+    vm.prank(captain);
+    shaman.onboard(toOnboard);
+    vm.warp(block.timestamp + 7200);
+
+    vm.prank(nonWearer);
+    shaman.quarter(toOnboard);
+
+    assertEq(sharesToken.balanceOf(nonWearer), startingShares);
+    assertEq(shaman.onboardingDelay(nonWearer), 0);
+  }
+
+  function test_notOnboarded() public {
+    address[] memory toOnboard = makeArray(nonWearer);
+
+    vm.prank(captain);
+    shaman.quarter(toOnboard);
+
+    assertEq(sharesToken.balanceOf(nonWearer), 0);
+  }
+}
+
+contract WithQuarteredTest is WithInstanceTest {
+  function setUp() public virtual override {
+    super.setUp();
+    address[] memory toOnboard = makeArray(nonWearer);
+
+    // onboard and quarter
+    vm.prank(captain);
+    shaman.onboard(toOnboard);
+    vm.warp(block.timestamp + 7200);
+    vm.prank(nonWearer);
+    shaman.quarter(toOnboard);
+  }
+}
+
+contract Offboarding is WithQuarteredTest {
+  function test_captain_canOffboard() public {
+    address[] memory toOffboard = makeArray(nonWearer);
+    uint256[] memory amounts = makeArray(startingShares);
+    vm.prank(captain);
+    vm.expectEmit(false, false, false, false);
+    emit OffboardedBatch(toOffboard, amounts, 0);
+    shaman.offboard(toOffboard);
+
+    assertGt(shaman.offboardingDelay(nonWearer), 0);
+  }
+
+  function test_notCaptain_noop() public {
+    address[] memory toOffboard = makeArray(nonWearer);
+    vm.prank(nonWearer);
+    vm.expectRevert(NotCaptain.selector);
+    shaman.offboard(toOffboard);
+
+    assertEq(shaman.offboardingDelay(nonWearer), 0);
+  }
+
+  function test_inQueue_noop() public {
+    address[] memory toOffboard = makeArray(nonWearer);
+
+    vm.prank(captain);
+    shaman.offboard(toOffboard);
+
+    uint256 delay = shaman.offboardingDelay(nonWearer);
+
+    vm.warp(block.timestamp + 3600);
+
+    vm.prank(captain);
+    shaman.offboard(toOffboard);
+
+    assertEq(shaman.offboardingDelay(nonWearer), delay);
+  }
+}
+
+contract Unquartering is WithQuarteredTest {
+
+  function setUp() public override {
+    super.setUp();
+
+    address[] memory toOffboard = makeArray(nonWearer);
+    vm.prank(captain);
+    shaman.offboard(toOffboard);
+  }
+
+  function test_canUnquarter() public {
+    address[] memory toUnquarter = makeArray(nonWearer);
+    vm.warp(block.timestamp + 7200);
+    vm.prank(nonWearer);
+
+    assertEq(sharesToken.balanceOf(nonWearer), startingShares);
+
+    shaman.unquarter(toUnquarter);
+
+    assertEq(sharesToken.balanceOf(nonWearer), 0);
+  }
+
+  function test_tooSoon_noop() public {
+    address[] memory toUnquarter = makeArray(nonWearer);
+    vm.warp(block.timestamp + 3600);
+
+    vm.prank(nonWearer);
+    shaman.unquarter(toUnquarter);
+
+    assertEq(sharesToken.balanceOf(nonWearer), startingShares);
+  }
+}

--- a/test/QuartermasterShaman.t.sol
+++ b/test/QuartermasterShaman.t.sol
@@ -83,9 +83,7 @@ contract WithInstanceTest is QuartermasterShamanTest {
     // encoded the initData as unpacked bytes -- for QuartermasterShaman, we just need any non-empty bytes
     initData = abi.encode(0);
     // deploy the instance
-    return QuartermasterShaman(
-      deployModuleInstance(factory, address(implementation), 0, otherImmutableArgs, initData)
-    );
+    return QuartermasterShaman(deployModuleInstance(factory, address(implementation), 0, otherImmutableArgs, initData));
   }
 
   function deployBaalWithShaman(string memory _name, string memory _symbol, bytes32 _saltNonce, address _shaman)
@@ -102,7 +100,7 @@ contract WithInstanceTest is QuartermasterShamanTest {
     permissions[0] = 2; // manager only
     bytes[] memory initializationActions = new bytes[](2);
     initializationActions[0] = abi.encodeCall(IBaal.setShamans, (shamans, permissions));
-    initializationActions[1] = abi.encodeCall(IBaal.setGovernanceConfig,(governanceConfig));
+    initializationActions[1] = abi.encodeCall(IBaal.setGovernanceConfig, (governanceConfig));
     // deploy the baal
     return IBaal(
       summoner.summonBaalFromReferrer(initializationParams, initializationActions, uint256(_saltNonce), "referrer")
@@ -130,9 +128,6 @@ contract WithInstanceTest is QuartermasterShamanTest {
   function grantShares(address _member, uint256 _amount) public {
     vm.prank(address(baal));
     sharesToken.mint(_member, _amount);
-  }
-
-  function setVotingPeriod(uint32 _period) public {
   }
 
   function makeArray(address _addr) public pure returns (address[] memory) {
@@ -166,8 +161,9 @@ contract WithInstanceTest is QuartermasterShamanTest {
     predictedBaalAddress = predictBaalAddress(SALT);
 
     // predict the shaman's address via the hats module factory
-    predictedShamanAddress =
-      factory.getHatsModuleAddress(address(implementation), 0, abi.encodePacked(predictedBaalAddress, captainHat, startingShares));
+    predictedShamanAddress = factory.getHatsModuleAddress(
+      address(implementation), 0, abi.encodePacked(predictedBaalAddress, captainHat, startingShares)
+    );
 
     // deploy a test baal with the predicted shaman address
     baal = deployBaalWithShaman("TEST_BAAL", "TEST_BAAL", SALT, predictedShamanAddress);
@@ -205,7 +201,6 @@ contract Deployment is WithInstanceTest {
   function test_startingShares() public {
     assertEq(shaman.STARTING_SHARES(), startingShares);
   }
-
 }
 
 contract Onboarding is WithInstanceTest {
@@ -366,7 +361,6 @@ contract Offboarding is WithQuarteredTest {
 }
 
 contract Unquartering is WithQuarteredTest {
-
   function setUp() public override {
     super.setUp();
 


### PR DESCRIPTION
This is a new shaman borrowing heavily from the onboarder shaman in this repository. It's intention is to give the captain (address holding the captain hat) the ability to bring new members to a DAO (adding them to the crew). Each crew member receives the minimum shares. In addition there is an onboarding delay so that if members notice the captain is making poor decisions in bringing on new members they can either ragequit or mutiny. The delay is twice the voting period to allow for this action.

I'm happy to work with the team to figure out how best to approach this. If there is another approach to introducing this module please let me know.